### PR TITLE
fix: guard MediaRecorder.stop() and protect ViewModel stop call

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,42 @@
+name: Android CI - build & unit tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+
+      - name: Install APT deps and Android commandline tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget unzip lib32stdc++6 libc6-i386 lib32z1
+          mkdir -p $HOME/android-sdk/cmdline-tools
+          wget https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip -O /tmp/cmdline.zip
+          unzip /tmp/cmdline.zip -d $HOME/android-sdk/cmdline-tools
+          mkdir -p $HOME/android-sdk/cmdline-tools/latest
+          mv $HOME/android-sdk/cmdline-tools/* $HOME/android-sdk/cmdline-tools/latest
+          export ANDROID_SDK_ROOT=$HOME/android-sdk
+          yes | $HOME/android-sdk/cmdline-tools/latest/bin/sdkmanager --sdk_root=${HOME}/android-sdk --licenses
+          $HOME/android-sdk/cmdline-tools/latest/bin/sdkmanager --sdk_root=${HOME}/android-sdk "platform-tools" "platforms;android-33" "build-tools;33.0.2"
+
+      - name: Show Java and Gradle
+        run: |
+          java -version
+          ./gradlew -v || true
+
+      - name: Run Gradle assembleDebug and unit tests
+        run: ./gradlew assembleDebug test --no-daemon

--- a/SUGGESTIONS.md
+++ b/SUGGESTIONS.md
@@ -52,3 +52,5 @@ Verplaats deze limieten naar een externe bron:
 
 **Suggestie:**
 Verwijder dit commentaar. De `InfoActivity` is inmiddels geïmplementeerd, dus het commentaar is verouderd en kan voor verwarring zorgen.
+
+* fix/audio-stop-protection — Guard MediaRecorder.stop() and ViewModel stop call to avoid IllegalStateException/RuntimeException crashes on some devices.

--- a/app/src/main/java/nl/jeoffrey/geluidsboetechecker/audio/AudioMeter.kt
+++ b/app/src/main/java/nl/jeoffrey/geluidsboetechecker/audio/AudioMeter.kt
@@ -41,9 +41,23 @@ class AudioMeter {
     }
 
     fun stop() {
-        mediaRecorder?.apply {
-            stop()
-            release()
+        mediaRecorder?.let { recorder ->
+            try {
+                // stop() may throw IllegalStateException or RuntimeException on some devices
+                // if the recorder wasn't properly started or was already stopped.
+                recorder.stop()
+            } catch (e: IllegalStateException) {
+                // swallow IllegalStateException to avoid crashes; continue to release.
+                // Optional: log using android.util.Log if available.
+            } catch (e: RuntimeException) {
+                // Some devices may throw other runtime exceptions - swallow to avoid crashes.
+            } finally {
+                try {
+                    recorder.release()
+                } catch (ignored: Exception) {
+                    // Ignore release failures - resource cleanup best-effort
+                }
+            }
         }
         mediaRecorder = null
     }

--- a/app/src/main/java/nl/jeoffrey/geluidsboetechecker/ui/MainViewModel.kt
+++ b/app/src/main/java/nl/jeoffrey/geluidsboetechecker/ui/MainViewModel.kt
@@ -59,7 +59,13 @@ class MainViewModel : ViewModel() {
 
     fun stopMeasurement() {
         measurementJob?.cancel()
-        audioMeter.stop()
+        try {
+            // Guard the call to stop() - audio subsystem may still throw on some devices.
+            audioMeter.stop()
+        } catch (e: Exception) {
+            // Guard against unexpected exceptions from the audio subsystem so the ViewModel doesn't crash.
+            // Optional: log the exception.
+        }
         _uiState.value = _uiState.value.copy(isMeasuring = false)
     }
 


### PR DESCRIPTION
* Harden AudioMeter.stop(): guard stop()/release() to avoid IllegalStateException/RuntimeException
* Guard audioMeter.stop() in MainViewModel.stopMeasurement()
* Add SUGGESTIONS.md note
* Add GitHub Actions workflow to run assembleDebug and unit tests