### PR TITLE
Inject AudioMeter dependency for MainViewModel tests

### DIFF
--- a/app/src/main/java/nl/jeoffrey/geluidsboetechecker/ui/MainViewModel.kt
+++ b/app/src/main/java/nl/jeoffrey/geluidsboetechecker/ui/MainViewModel.kt
@@ -22,9 +22,9 @@ data class UiState(
     val errorMessage: String? = null
 )
 
-class MainViewModel : ViewModel() {
+class MainViewModel(private val audioMeter: AudioMeter) : ViewModel() {
 
-    private val audioMeter = AudioMeter()
+    constructor() : this(AudioMeter())
     private var measurementJob: Job? = null
 
     private val _uiState = MutableStateFlow(UiState())

--- a/app/src/test/java/nl/jeoffrey/geluidsboetechecker/ui/MainViewModelTest.kt
+++ b/app/src/test/java/nl/jeoffrey/geluidsboetechecker/ui/MainViewModelTest.kt
@@ -35,12 +35,7 @@ class MainViewModelTest {
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         audioMeter = mock()
-        viewModel = MainViewModel()
-        // This is a bit of a hack, but since audioMeter is private, we use reflection to inject the mock.
-        // A better solution would be to use dependency injection.
-        val audioMeterField = viewModel::class.java.getDeclaredField("audioMeter")
-        audioMeterField.isAccessible = true
-        audioMeterField.set(viewModel, audioMeter)
+        viewModel = MainViewModel(audioMeter)
     }
 
     @After


### PR DESCRIPTION
## Summary
- allow `MainViewModel` to receive an `AudioMeter` dependency while retaining a no-arg constructor for production use
- simplify `MainViewModelTest` setup by injecting the mocked `AudioMeter` instead of using reflection

## Testing
- `./gradlew test` *(fails: SDK location not found; Android SDK not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942e32e7704832f859d84ba483f8823)