### PR TITLE
Fix build and unit test hanging issues

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "nl.jeoffrey.geluidsboetechecker"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "nl.jeoffrey.geluidsboetechecker"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 
@@ -40,6 +40,11 @@ android {
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.14"
+    }
+    testOptions {
+        unitTests.all {
+            it.maxHeapSize = "2048m"
+        }
     }
 }
 

--- a/app/src/main/java/nl/jeoffrey/geluidsboetechecker/audio/AudioMeterException.kt
+++ b/app/src/main/java/nl/jeoffrey/geluidsboetechecker/audio/AudioMeterException.kt
@@ -1,3 +1,3 @@
 package nl.jeoffrey.geluidsboetechecker.audio
 
-class AudioMeterException(message: String, cause: Throwable? = null) : Exception(message, cause)
+class AudioMeterException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/app/src/test/java/nl/jeoffrey/geluidsboetechecker/ui/MainViewModelTest.kt
+++ b/app/src/test/java/nl/jeoffrey/geluidsboetechecker/ui/MainViewModelTest.kt
@@ -54,10 +54,12 @@ class MainViewModelTest {
         whenever(audioMeter.getDbLevel()).thenReturn(50.0)
 
         viewModel.startMeasurement()
-        testDispatcher.scheduler.advanceUntilIdle()
+        testDispatcher.scheduler.runCurrent()
 
         assertEquals(true, viewModel.uiState.value.isMeasuring)
         assertEquals(50.0, viewModel.uiState.value.dbLevel, 0.0)
+
+        viewModel.stopMeasurement()
     }
 
     @Test
@@ -73,7 +75,7 @@ class MainViewModelTest {
     @Test
     fun `stopMeasurement updates uiState`() = runTest {
         viewModel.startMeasurement()
-        testDispatcher.scheduler.advanceUntilIdle()
+        testDispatcher.scheduler.runCurrent()
         viewModel.stopMeasurement()
 
         assertEquals(false, viewModel.uiState.value.isMeasuring)

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,6 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+# Suppress the unsupported compileSdk warning for Android SDK 35 with AGP 8.4.1
+android.suppressUnsupportedCompileSdk=35


### PR DESCRIPTION
This commit updates compileSdk/targetSdk to 35 to resolve dependencies' requirements, increases test JVM heap size to prevent OOMs, and fixes an infinite-loop hang in coroutine unit tests.

---
*PR created automatically by Jules for task [18011591058388603801](https://jules.google.com/task/18011591058388603801) started by @CactusJC*