### PR TITLE
Fix App Debug and Unit Test Blockers

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "nl.jeoffrey.geluidsboetechecker"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "nl.jeoffrey.geluidsboetechecker"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 
@@ -41,6 +41,10 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.14"
     }
+}
+
+tasks.withType<Test> {
+    maxHeapSize = "1024m"
 }
 
 dependencies {

--- a/app/src/main/java/nl/jeoffrey/geluidsboetechecker/audio/AudioMeterException.kt
+++ b/app/src/main/java/nl/jeoffrey/geluidsboetechecker/audio/AudioMeterException.kt
@@ -1,3 +1,3 @@
 package nl.jeoffrey.geluidsboetechecker.audio
 
-class AudioMeterException(message: String, cause: Throwable? = null) : Exception(message, cause)
+class AudioMeterException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/app/src/test/java/nl/jeoffrey/geluidsboetechecker/ui/MainViewModelTest.kt
+++ b/app/src/test/java/nl/jeoffrey/geluidsboetechecker/ui/MainViewModelTest.kt
@@ -40,6 +40,7 @@ class MainViewModelTest {
 
     @After
     fun tearDown() {
+        viewModel.stopMeasurement()
         Dispatchers.resetMain()
     }
 
@@ -54,10 +55,12 @@ class MainViewModelTest {
         whenever(audioMeter.getDbLevel()).thenReturn(50.0)
 
         viewModel.startMeasurement()
-        testDispatcher.scheduler.advanceUntilIdle()
+        testDispatcher.scheduler.runCurrent()
 
         assertEquals(true, viewModel.uiState.value.isMeasuring)
         assertEquals(50.0, viewModel.uiState.value.dbLevel, 0.0)
+
+        viewModel.stopMeasurement()
     }
 
     @Test
@@ -73,7 +76,7 @@ class MainViewModelTest {
     @Test
     fun `stopMeasurement updates uiState`() = runTest {
         viewModel.startMeasurement()
-        testDispatcher.scheduler.advanceUntilIdle()
+        testDispatcher.scheduler.runCurrent()
         viewModel.stopMeasurement()
 
         assertEquals(false, viewModel.uiState.value.isMeasuring)


### PR DESCRIPTION
This pull request fixes critical build, test, and debugging blockers for the Geluidsboete Checker NL app.

Key changes:
1. Resolved Compose 1.8.1 Android SDK compilation compatibility requirements by bumping compileSdk and targetSdk to 35.
2. Resolved Mockito checked exception stubbing errors by subclassing AudioMeterException from RuntimeException.
3. Fixed unit test hangs (which caused high CPU and out-of-memory errors) by switching advanceUntilIdle() to runCurrent() and ensuring all coroutines are properly stopped in tearDown().
4. Ensured stable JVM test execution by setting maxHeapSize = '1024m' for unit tests.

---
*PR created automatically by Jules for task [3609661061613615539](https://jules.google.com/task/3609661061613615539) started by @CactusJC*